### PR TITLE
fix переполнения BIGINT в SQL запросе

### DIFF
--- a/classes/dbo.p
+++ b/classes/dbo.p
@@ -665,8 +665,9 @@ LEFT JOIN items last_parent ON last_parent.iid = last_parent_nd.iid
 WHERE 
 t2.user_id = $USERID AND
 i.user_id = $USERID AND
-(last_parent_nd.level = transaction_for_last_parent_nd.level-1 
-OR transaction_for_last_parent_nd.level = 0)
+(transaction_for_last_parent_nd.level = 0
+OR last_parent_nd.level = transaction_for_last_parent_nd.level-1
+)
 AND
 last_parent_nd.pid = last_parent_nd.iid
 


### PR DESCRIPTION
-fix: Исправил запрос так, чтобы не возникало ситуации переполнения UNSIGNED BIGINT при вычитании 1 из 0.
